### PR TITLE
[feat]: 페이지 새로고침시에도 로그인 유지되도록 수정 완료

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -62,7 +62,6 @@ export const getUserInfo = async (): Promise<TUserInfo | null> => {
     return res.data
   } catch (error) {
 
-    console.error("getUserInfo error:", error);
     return null;
   }
 };

--- a/src/common/axio-interceptor.ts
+++ b/src/common/axio-interceptor.ts
@@ -5,11 +5,8 @@ import LocalStorage from './LocalStorage';
 
 const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_HOST,
-  headers: {
-    Authorization: `Bearer `,
-  },
+  withCredentials: true,
 });
-axios.defaults.withCredentials = true;
 
 export const setToken = (accessToken: string, refreshToken: string) => {
   instance.defaults.headers.common['Authorization'] = 'Bearer ' + accessToken;
@@ -21,13 +18,11 @@ export const removeToken = async () => {
   LocalStorage.removeItem('accessToken');
   LocalStorage.removeItem('refreshToken');
   instance.defaults.headers.common['Authorization'] = 'Bearer ';
-  instance.defaults.headers['Authorization'] = 'Bearer ';
 };
 
 export const initAxios = (tokenInfo?: TToken) => {
   if (tokenInfo?.accessToken) {
     instance.defaults.headers.common['Authorization'] = 'Bearer ' + tokenInfo.accessToken;
-    instance.defaults.headers['Authorization'] = 'Bearer ' + tokenInfo.accessToken;
   }
 };
 

--- a/src/components/common/header/header.container.tsx
+++ b/src/components/common/header/header.container.tsx
@@ -36,7 +36,7 @@ export default function HeaderContainer() {
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
-      if (!token) {
+      if (!token?.accessToken && !token?.refreshToken) {
         const accessToken = LocalStorage.getItem('accessToken');
         const refreshToken = LocalStorage.getItem('refreshToken');
 
@@ -44,11 +44,9 @@ export default function HeaderContainer() {
           setToken({ accessToken, refreshToken });
           initAxios({ accessToken, refreshToken });
         }
-        return;
       }
-      initAxios();
     }
-  }, [token, setToken, initAxios]);
+  }, [token, setToken]);
 
   const movePage = (path: string) => {
     setIsOpenMenu(false);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f01f2a2f-684f-4b00-bd85-d08d08078df4)

기존
-> 페이지 새로고침시 토큰은 남아있으나 리코일에 토큰이 사라짐

수정
-> 페이지가 새로고침 되었을 때 로컬스토리지에서 토큰을 가져와 리코일에 새로 저장