### PR TITLE
[feat]: 전역토큰관리 완성

### DIFF
--- a/src/components/common/header/header.container.tsx
+++ b/src/components/common/header/header.container.tsx
@@ -1,4 +1,4 @@
-import { RecoilState } from 'recoil';
+import { RecoilState, useRecoilValue } from 'recoil';
 import { useRouter, usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useRecoilState } from 'recoil';
@@ -7,16 +7,40 @@ import { getUserInfo } from '@/api/auth';
 import { tokenAtom } from '@/recoil/auth/atom';
 import { userInfoAtom } from '@/recoil/mypage/atom';
 import LocalStorage from '@/common/LocalStorage';
-import { initAxios, removeToken } from '@/common/axio-interceptor';
+import instance, { initAxios, removeToken, setToken } from '@/common/axio-interceptor';
 import HeaderPresenter from './header.presenter';
 import type { TUserInfo } from '@/type/auth';
+import { useTokenUpdater } from '@/hooks/auth/useTokenUpdater';
+import axios from 'axios';
 
 export default function HeaderContainer() {
   const pathname = usePathname();
   const router = useRouter();
-  const [token, setToken] = useRecoilState<{ accessToken: string; refreshToken: string } | null>(tokenAtom as RecoilState<{ accessToken: string; refreshToken: string } | null>);
+  const token = useRecoilValue(tokenAtom);
   const [userInfo, setUserInfo] = useRecoilState<TUserInfo | null>(userInfoAtom as RecoilState<TUserInfo | null>);
   const [isOpenMenu, setIsOpenMenu] = useState<boolean>(false);
+  const updateToken = useTokenUpdater();
+
+  useEffect(() => {
+    const refreshToken = LocalStorage.getItem('refreshToken');
+  
+    if (refreshToken && !(token?.accessToken)) {
+      axios.post(`${process.env.NEXT_PUBLIC_API_HOST}auth/refresh`, { refresh_token: refreshToken })
+        .then(response => {
+          const { access_token, refresh_token } = response.data;
+          if (access_token && refresh_token) {
+            setToken(access_token, refresh_token);
+            updateToken(access_token, refresh_token);
+          } else {
+            throw new Error('Invalid token response');
+          }
+        })
+        .catch(error => {
+          console.error('Failed to refresh access token on load:', error);
+          removeToken();
+        });
+    }
+  }, [token, updateToken]);
 
   useSWR<TUserInfo | null>(
     () => (!!token && !userInfo ? 'getUserInfo' : null),
@@ -41,22 +65,17 @@ export default function HeaderContainer() {
     }
   };
 
+  const handleTokenUpdate = (accessToken: string | null, refreshToken: string | null) => {
+    if (accessToken && refreshToken) {
+      updateToken(accessToken, refreshToken);
+    }  };
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      if (!token?.accessToken && !token?.refreshToken) {
-        const accessToken = LocalStorage.getItem('accessToken');
-        const refreshToken = LocalStorage.getItem('refreshToken');
-
-        if (accessToken && refreshToken) {
-          setToken({ accessToken, refreshToken });
-          initAxios({ accessToken, refreshToken });
-        }
-      } else {
-        updateUserInfo();
-      }
+    if (token?.accessToken) {
+      initAxios(token);
+      updateUserInfo();
     }
-  }, [token, setToken]);
+  }, [token?.accessToken]);
 
   const movePage = (path: string) => {
     setIsOpenMenu(false);

--- a/src/components/views/auth/Login.tsx
+++ b/src/components/views/auth/Login.tsx
@@ -50,7 +50,6 @@ export default function LoginPage() {
             const { accessToken, refreshToken } = res.data;
             setToken(accessToken, refreshToken);
             setTokenState({ accessToken, refreshToken });
-            console.log('로그인 성공');
 
             if (localStorage.getItem('상세페이지에서로그인') === 'true') {
               localStorage.removeItem('상세페이지에서로그인');

--- a/src/hooks/auth/useTokenUpdater.ts
+++ b/src/hooks/auth/useTokenUpdater.ts
@@ -1,0 +1,10 @@
+import { useSetRecoilState } from 'recoil';
+import { tokenAtom } from '@/recoil/auth/atom';
+
+export function useTokenUpdater() {
+  const setRecoilToken = useSetRecoilState(tokenAtom);
+
+  return (accessToken: string | null, refreshToken: string | null) => {
+    setRecoilToken({ accessToken, refreshToken });
+  };
+}

--- a/src/type/auth.ts
+++ b/src/type/auth.ts
@@ -1,7 +1,7 @@
 export type TToken = {
-  accessToken: string;
-  refreshToken: string;
-} | null; // null을 허용하도록 수정
+  accessToken: string | null;
+  refreshToken: string | null;
+};
 
 export type TUserInfo = {
   name: string; //'박현민';


### PR DESCRIPTION
서버에서 새로운 토큰 발급 완료, 로컬스토리지에 refreshToken 저장, 전역변수와, recoil에 accessToken 저장.

![스크린샷 2024-10-16 023915](https://github.com/user-attachments/assets/4d7a5eb4-ccba-4e45-8eb8-984bc0372aef)
 
![스크린샷 2024-10-16 023831](https://github.com/user-attachments/assets/786b8b8d-b308-4572-b8c6-3dca7222ece6)
